### PR TITLE
Fix CI failures: sync frontend lockfile and bump Go builder image to 1.25

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.24 AS builder
+FROM golang:1.25 AS builder
 
 WORKDIR /app
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -12581,6 +12581,24 @@
         "node": ">=4"
       }
     },
+    "node_modules/tailwindcss/node_modules/yaml": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "dev": true,
+      "license": "ISC",
+      "optional": true,
+      "peer": true,
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
+    },
     "node_modules/tapable": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.3.tgz",


### PR DESCRIPTION
## Problem

Two workflows are failing on `main`:

1. **CI / Frontend Test**: `npm ci` fails with `Missing: yaml@2.9.0 from lock file` — `frontend/package-lock.json` was out of sync with `package.json`.
2. **Docker Compose Build Check**: `go mod download` fails with `go.mod requires go >= 1.25.0 (running go 1.24.13)` — the backend Dockerfile still used `golang:1.24`.

## Changes

- Regenerate `frontend/package-lock.json` (`npm install --package-lock-only`) to add the missing `yaml@2.9.0` entry
- Bump `backend/Dockerfile` builder image from `golang:1.24` to `golang:1.25`

## Verification

- `npm ci`, `npm run lint`, `npm run build` all pass locally (Node 20 / npm 10.8.2, same as CI)
- `docker compose build backend` succeeds locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)